### PR TITLE
Delete pointless return statement

### DIFF
--- a/futhark_data/__init__.py
+++ b/futhark_data/__init__.py
@@ -493,7 +493,7 @@ decide based on the type of ``f``.
     if binary:
         f.write(construct_binary_value(v))
     else:
-        return dump_text(v, f)
+        dump_text(v, f)
 
 def dumps(v):
     """Returns the textual representation of the argument."""


### PR DESCRIPTION
Return statement always returns class 'NoneType'. Doesn't make sense for there to be a return type for function that simply writes to file.